### PR TITLE
unbound.service.in: do not fork into the background

### DIFF
--- a/contrib/unbound.service.in
+++ b/contrib/unbound.service.in
@@ -10,7 +10,7 @@ WantedBy=multi-user.target
 
 [Service]
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=@UNBOUND_SBIN_DIR@/unbound
+ExecStart=@UNBOUND_SBIN_DIR@/unbound -d
 NotifyAccess=main
 Type=notify
 CapabilityBoundingSet=CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID CAP_SYS_CHROOT CAP_SYS_RESOURCE CAP_NET_RAW


### PR DESCRIPTION
This is needed when unbound config doesn't set `do-daemonize: no` by itself otherwise starting service fails with:
` systemd[1]: unbound.service: Got notification message from PID <PID>, but reception only permitted for main PID which is currently not known`

https://github.com/NLnetLabs/unbound/blob/release-1.9.3/doc/example.conf.in#L236